### PR TITLE
Add argument to stopPropagation method

### DIFF
--- a/src/L.Control.Sidebar.js
+++ b/src/L.Control.Sidebar.js
@@ -42,9 +42,9 @@ L.Control.Sidebar = L.Control.extend({
             var close = L.DomUtil.create('a', 'close', container);
             close.innerHTML = '&times;';
 
-            L.DomEvent.on(close, 'click', function () {
+            L.DomEvent.on(close, 'click', function (e) {
                 sidebar.hide();
-                L.DomEvent.stopPropagation();
+                L.DomEvent.stopPropagation(e);
             });
         }
 


### PR DESCRIPTION
Currently returns the following error when closing the sidebar by clicking the 'X' button: `Uncaught TypeError: Cannot read property 'stopPropagation' of undefined`
