### PR TITLE
Refactored code, so that sidebar cleans up after itself and is reusable

### DIFF
--- a/src/L.Control.Sidebar.js
+++ b/src/L.Control.Sidebar.js
@@ -29,15 +29,12 @@ L.Control.Sidebar = L.Control.extend({
 
         // Create close button and attach it if configured
         if (this.options.closeButton) {
-            var sidebar = this;
-
             var close = this._closeButton =
                 L.DomUtil.create('a', 'close', container);
             close.innerHTML = '&times;';
         }
     },
     addTo: function (map) {
-        var sidebar = this;
         var container = this._container;
         var content = this._contentContainer;
 


### PR DESCRIPTION
Example:

```
sidebar.addTo(map);
sidebar.removeFrom(map); //events still registered, memory leak
sidebar.addTo(map); //container created again, events registered again
```
- Turned off events in removeFrom to prevent memory leaks
- Refactored container setup into initialize, to allow multiple calls to
  addTo and removeFrom.
- If removeFrom is called while the sidebar is displayed, the sidebar will
  hide itself first to restore map pane as well as prevent itself from being
  displayed by default if addTo is called.
