### PR TITLE
add support for component.io. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ npm-debug.log
 node_modules
 
 dist
+build

--- a/component.json
+++ b/component.json
@@ -1,0 +1,14 @@
+{
+  "name": "leaflet-sidebar",
+  "version": "0.1.4",
+  "repo": "Turbo87/leaflet-sidebar",
+  "description": "A responsive sidebar plugin for for Leaflet",
+  "keywords": [
+    "gis",
+    "leaflet",
+    "leaflet-plugin",
+    "map"
+  ],
+  "scripts": ["src/L.Control.Sidebar.js"],
+  "styles": ["src/L.Control.Sidebar.css"]
+}


### PR DESCRIPTION
Leaflet/Leaflet dep is missing (see below) as Leaflet's repo has not yet promoted component changes?

https://github.com/Leaflet/Leaflet/commit/ce4b77fe811f6ade59eabfdebaf4991c3938cf59

You will need to manually add this bit once that is done:

``` json
"dependencies": {
    "leaflet/leaflet": "0.6.x"
  },
```
