### PR TITLE
popup closing button: centering label

### DIFF
--- a/src/L.Control.Sidebar.css
+++ b/src/L.Control.Sidebar.css
@@ -86,7 +86,7 @@
     width: 31px;
     height: 31px;
     color: #333;
-    font-size: 25pt;
+    font-size: 25px;
     line-height: 1em;
     text-align: center;
     background: white;


### PR DESCRIPTION
this makes `close-button`'s label centered