### PR TITLE
allow setContent() to accept HTML DOM element object

### DIFF
--- a/src/L.Control.Sidebar.js
+++ b/src/L.Control.Sidebar.js
@@ -161,15 +161,20 @@ L.Control.Sidebar = L.Control.extend({
     },
 
     setContent: function (content) {
-        if (typeof content === 'string') {
-            this.getContainer().innerHTML = content;
-        } else {
-            this._content = content;
-        }
+      var container = this.getContainer();
 
-        this.update();
-        
-        return this;
+      if (typeof content === 'string') {
+          container.innerHTML = content;
+      } else {
+          // clean current content
+          while (container.firstChild) {
+              container.removeChild(container.firstChild);
+          }
+
+          container.appendChild(content);
+      }
+
+      return this;
     },
 
     getOffset: function () {

--- a/src/L.Control.Sidebar.js
+++ b/src/L.Control.Sidebar.js
@@ -161,7 +161,14 @@ L.Control.Sidebar = L.Control.extend({
     },
 
     setContent: function (content) {
-        this.getContainer().innerHTML = content;
+        if (typeof content === 'string') {
+            this.getContainer().innerHTML = content;
+        } else {
+            this._content = content;
+        }
+
+        this.update();
+        
         return this;
     },
 

--- a/src/L.Control.Sidebar.js
+++ b/src/L.Control.Sidebar.js
@@ -161,20 +161,20 @@ L.Control.Sidebar = L.Control.extend({
     },
 
     setContent: function (content) {
-      var container = this.getContainer();
+        var container = this.getContainer();
 
-      if (typeof content === 'string') {
-          container.innerHTML = content;
-      } else {
-          // clean current content
-          while (container.firstChild) {
-              container.removeChild(container.firstChild);
-          }
+        if (typeof content === 'string') {
+            container.innerHTML = content;
+        } else {
+            // clean current content
+            while (container.firstChild) {
+                container.removeChild(container.firstChild);
+            }
 
-          container.appendChild(content);
-      }
+            container.appendChild(content);
+        }
 
-      return this;
+        return this;
     },
 
     getOffset: function () {


### PR DESCRIPTION
This pull request allows setContent() to accept HTML DOM element object as input. It would provide convenience to render dynamically compiled content, especially for those whose HTML element isn't generated immediately (like [Angular](http://stackoverflow.com/questions/26660495/can-i-get-the-compiled-html-of-an-angular-element)).