### PR TITLE
Fix sidebar content scrolling for Leaflet 1.7

### DIFF
--- a/src/L.Control.Sidebar.js
+++ b/src/L.Control.Sidebar.js
@@ -68,6 +68,8 @@ L.Control.Sidebar = L.Control.extend({
             .on(content, 'touchstart', stop)
             .on(content, 'dblclick', fakeStop)
             .on(content, 'mousewheel', stop)
+            .on(content, 'wheel', stop)
+            .on(content, 'scroll', stop)
             .on(content, 'MozMousePixelScroll', stop);
 
         return this;
@@ -97,6 +99,8 @@ L.Control.Sidebar = L.Control.extend({
             .off(content, 'touchstart', stop)
             .off(content, 'dblclick', fakeStop)
             .off(content, 'mousewheel', stop)
+            .off(content, 'wheel', stop)
+            .off(content, 'scroll', stop)
             .off(content, 'MozMousePixelScroll', stop);
 
         L.DomEvent


### PR DESCRIPTION
Leaflet 1.7 now listens on the generic 'wheel' event to zoom the map, resulting in the map being zoomed while content in a sidebar was scrolled. This fix prevents that.